### PR TITLE
working example without performance optimization (N+1 queries)

### DIFF
--- a/.meshrc.yml
+++ b/.meshrc.yml
@@ -11,3 +11,23 @@ sources:
           - articles
           - article_to_categories
           - article_categories
+
+
+additionalTypeDefs: |
+  extend type articles {
+    categories: [article_categories]
+  }
+additionalResolvers:
+  - targetTypeName: articles
+    targetFieldName: categories
+    sourceName: relationtest # Which source does the target field belong to?
+    sourceTypeName: Query # Which root type does the target field belong to?
+    sourceFieldName: article_categories # What is the source field name?
+    # we need the following selection set to pass it to the underlying query (Query.article_categories(where: { id:...}))
+    requiredSelectionSet:
+      |
+      {
+        id
+      }
+    sourceArgs: # What args does this need to take?
+      where.id: "{root.id}" # `root` refers to the current selectionSet

--- a/README.md
+++ b/README.md
@@ -8,3 +8,18 @@ then
 ` yarn install ` 
 ` yarn graphql-mesh dev`
 
+
+### Target Query design
+
+```graphql
+query MyQuery {
+  articles {
+    content
+    id
+    title
+    categories {
+      title
+    }
+  }
+}
+```


### PR DESCRIPTION
Hi @appcoders,

I hope this will help you reproduce the same setup on your project.
Normally GraphQL Mesh would allow [avoiding N+1 queries by batching them](https://www.graphql-mesh.com/docs/guides/performances-best-practices), however, given the generated GraphQL Queries (from the SQL tables), it is not possible for now.
We took note of this limitation and will look into adding "batch friendly" generated queries to the `sql` handler.


<img width="1255" alt="Screenshot 2022-05-30 at 17 55 08" src="https://user-images.githubusercontent.com/1252066/171027780-550e1793-f8a7-4b45-85be-44e61f7f547f.png">
